### PR TITLE
fix: data flow 변경

### DIFF
--- a/src/components/ImageUpload.tsx
+++ b/src/components/ImageUpload.tsx
@@ -4,7 +4,7 @@ import Button from './Button';
 import DefaultImgUrl from '../assets/default.svg';
 
 type ImageUploadProps = {
-	profileImage: string;
+	profileImage?: string;
 };
 
 const ImageUpload = ({ profileImage }: ImageUploadProps) => {

--- a/src/components/ImageUpload.tsx
+++ b/src/components/ImageUpload.tsx
@@ -1,10 +1,13 @@
 import { useState, useRef, useEffect } from 'react';
 import { useFormContext } from 'react-hook-form';
-import { getCookie } from '../util/function/getCookie';
 import Button from './Button';
 import DefaultImgUrl from '../assets/default.svg';
 
-const ImageUpload = () => {
+type ImageUploadProps = {
+	profileImage: string;
+};
+
+const ImageUpload = ({ profileImage }: ImageUploadProps) => {
 	const [imageUrl, setImageUrl] = useState<string>(DefaultImgUrl);
 	const [imageName, setImageName] = useState<string | undefined>('-');
 
@@ -13,7 +16,6 @@ const ImageUpload = () => {
 	const { setValue, watch } = useFormContext();
 
 	useEffect(() => {
-		const profileImage = getCookie('profileImage');
 		if (profileImage == 'undefined') {
 			setImageName('-');
 		}

--- a/src/pages/Login/components/LoginForm.tsx
+++ b/src/pages/Login/components/LoginForm.tsx
@@ -1,46 +1,19 @@
-import { useEffect, useState } from 'react';
 import { FieldValues, SubmitHandler, useFormContext } from 'react-hook-form';
-import { useNavigate } from 'react-router-dom';
-import { getCookie } from '../../../util/function/getCookie';
+import useCheckAccount from '../../../util/customHook/useCheckAccount';
 
 type LoginFormProps = {
 	children: React.ReactNode;
 };
 
 const LoginForm = ({ children }: LoginFormProps) => {
-	const [loginTryCount, setLoginTryCount] = useState(0);
-	const navigate = useNavigate();
 	const { handleSubmit } = useFormContext();
 
+	const { handleCheckAccount } = useCheckAccount();
+
 	const onSubmit: SubmitHandler<FieldValues> = (formFieldData) => {
-		const cookieData = {
-			id: getCookie('id'),
-			pw: getCookie('pw'),
-		};
-
-		if (formFieldData.id !== cookieData.id) {
-			alert('존재하지 않는 아이디입니다.');
-			return;
-		}
-		if (formFieldData.pw !== cookieData.pw) {
-			alert('비밀번호가 일치하지 않습니다.');
-			setLoginTryCount(loginTryCount + 1);
-
-			if (loginTryCount >= 2) {
-				alert('로그인 시도 횟수를 초과하였습니다. 잠시 후 다시 시도해주세요.');
-				throw new Error('잘못된 로그인 시도 3회 초과');
-			}
-			return;
-		}
-
-		navigate('/myinfo');
+		const { id, pw } = formFieldData;
+		handleCheckAccount(id, pw);
 	};
-
-	useEffect(() => {
-		if (loginTryCount >= 3) {
-			throw new Error('잘못된 로그인 시도 3회 초과');
-		}
-	}, [loginTryCount]);
 
 	return <form onSubmit={handleSubmit(onSubmit)}>{children}</form>;
 };

--- a/src/pages/Login/components/LoginForm.tsx
+++ b/src/pages/Login/components/LoginForm.tsx
@@ -1,8 +1,6 @@
 import { useEffect, useState } from 'react';
-import { ErrorBoundary } from 'react-error-boundary';
 import { FieldValues, SubmitHandler, useFormContext } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
-import ErrorFallback from '../../../components/ErrorFallback';
 import { getCookie } from '../../../util/function/getCookie';
 
 type LoginFormProps = {

--- a/src/pages/MyInfo/MyInfoPage.tsx
+++ b/src/pages/MyInfo/MyInfoPage.tsx
@@ -1,9 +1,9 @@
+import { useEffect } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import Button from '../../components/Button';
 import ImageUpload from '../../components/ImageUpload';
 import Input from '../../components/Input';
 import { AuthService } from '../../service/AuthService';
-import { getCookie } from '../../util/function/getCookie';
 import LogOutButton from './components/LogOutButton';
 import MyInfoForm from './components/MyInfoForm';
 import { formSchema } from './formSchema';
@@ -17,13 +17,25 @@ const MyInfoPage = () => {
 	const form = useForm({
 		resolver: zodResolver(formSchema),
 		defaultValues: {
-			profileImage: data?.profileImage || getCookie('profileImage') || '-',
-			id: data?.id || getCookie('id') || '-',
-			name: data?.name || getCookie('name') || '-',
-			createdAt: data?.createdAt || getCookie('createdAt') || '-',
-			updatedAt: data?.updatedAt || getCookie('updatedAt') || '-',
+			profileImage: data?.profileImage || '-',
+			id: data?.id || '-',
+			name: data?.name || '-',
+			createdAt: data?.createdAt || '-',
+			updatedAt: data?.updatedAt || '-',
 		},
 	});
+
+	useEffect(() => {
+		if (data) {
+			form.reset({
+				profileImage: data.profileImage,
+				id: data.id,
+				name: data.name,
+				createdAt: data.createdAt,
+				updatedAt: data.updatedAt,
+			});
+		}
+	}, [data]);
 
 	const {
 		register,

--- a/src/pages/MyInfo/MyInfoPage.tsx
+++ b/src/pages/MyInfo/MyInfoPage.tsx
@@ -46,7 +46,7 @@ const MyInfoPage = () => {
 		<>
 			<FormProvider {...form}>
 				<MyInfoForm>
-					<ImageUpload />
+					<ImageUpload profileImage={data?.profileImage || '-'} />
 					<div className="input-wrapper">
 						<Input readOnly {...register('id')} />
 					</div>

--- a/src/pages/MyInfo/components/MyInfoForm.tsx
+++ b/src/pages/MyInfo/components/MyInfoForm.tsx
@@ -11,7 +11,7 @@ const MyInfoForm = ({ children }: MyInfoFormProp) => {
 	const { handleSubmit, watch } = useFormContext();
 
 	const authService = new AuthService();
-	const { mutate, isPending } = authService.useUpdateMyInfoMutation();
+	const { mutateAsync, isPending } = authService.useUpdateMyInfoMutation();
 
 	const onSubmit: SubmitHandler<FieldValues> = (formFieldData) => {
 		const name = formFieldData.name;
@@ -26,7 +26,11 @@ const MyInfoForm = ({ children }: MyInfoFormProp) => {
 			updatedAt,
 		};
 
-		mutate(payload);
+		mutateAsync(payload)
+			.then(() => {
+				alert('정보가 수정되었습니다.');
+			})
+			.catch(console.error);
 	};
 	return isPending ? (
 		<LoadingFallback isPending />

--- a/src/pages/SignUp/components/SignUpForm.tsx
+++ b/src/pages/SignUp/components/SignUpForm.tsx
@@ -35,7 +35,10 @@ const SignUpForm = ({ children }: SignUpFormProps) => {
 		};
 
 		mutateAsync(payload)
-			.then(() => navigate('/'))
+			.then(() => {
+				navigate('/');
+				alert('회원가입이 완료되었습니다.');
+			})
 			.catch(console.error);
 	};
 

--- a/src/pages/SignUp/components/SignUpForm.tsx
+++ b/src/pages/SignUp/components/SignUpForm.tsx
@@ -34,7 +34,9 @@ const SignUpForm = ({ children }: SignUpFormProps) => {
 			updatedAt,
 		};
 
-		mutateAsync(payload).then(() => navigate('/'));
+		mutateAsync(payload)
+			.then(() => navigate('/'))
+			.catch(console.error);
 	};
 
 	return isPending ? (

--- a/src/pages/SignUp/components/SignUpForm.tsx
+++ b/src/pages/SignUp/components/SignUpForm.tsx
@@ -1,4 +1,5 @@
 import { FieldValues, SubmitHandler, useFormContext } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
 import ErrorFallback from '../../../components/ErrorFallback';
 import LoadingFallback from '../../../components/LoadingFallback';
 import { AuthService } from '../../../service/AuthService';
@@ -11,8 +12,11 @@ type SignUpFormProps = {
 const SignUpForm = ({ children }: SignUpFormProps) => {
 	const { handleSubmit, watch } = useFormContext();
 
+	const navigate = useNavigate();
+
 	const authService = new AuthService();
-	const { mutate, isPending, isError } = authService.usePostSignUpMutation();
+	const { mutateAsync, isPending, isError } =
+		authService.usePostSignUpMutation();
 
 	const onSubmit: SubmitHandler<FieldValues> = (formFieldData) => {
 		const { pwConfirm, ...postData } = formFieldData;
@@ -30,7 +34,7 @@ const SignUpForm = ({ children }: SignUpFormProps) => {
 			updatedAt,
 		};
 
-		mutate(payload);
+		mutateAsync(payload).then(() => navigate('/'));
 	};
 
 	return isPending ? (

--- a/src/pages/SignUp/components/SignUpForm.tsx
+++ b/src/pages/SignUp/components/SignUpForm.tsx
@@ -12,7 +12,7 @@ const SignUpForm = ({ children }: SignUpFormProps) => {
 	const { handleSubmit, watch } = useFormContext();
 
 	const authService = new AuthService();
-	const { mutate, isPending, isError } = authService.useSignUpMutation();
+	const { mutate, isPending, isError } = authService.usePostSignUpMutation();
 
 	const onSubmit: SubmitHandler<FieldValues> = (formFieldData) => {
 		const { pwConfirm, ...postData } = formFieldData;

--- a/src/service/AuthService.ts
+++ b/src/service/AuthService.ts
@@ -27,20 +27,19 @@ export class AuthService {
 	};
 
 	private postSignUp = async (payload: FieldValues) => {
-		return axios.post(`${this.URL}/api/auth/sign-up`, payload);
+		return Object.entries(payload).forEach(([key, value]) => {
+			document.cookie = `${key}=${value}; path=/`;
+		});
 	};
 
 	private updateMyInfo = async (payload: FieldValues) => {
-		return axios.patch(`${this.URL}/api/auth/my-info`, payload);
+		return Object.entries(payload).forEach(([key, value]) => {
+			document.cookie = `${key}=${value}; path=/`;
+		});
 	};
 
 	private mutationOptions = {
 		retry: 3,
-		onMutate: (payload: FieldValues) => {
-			Object.entries(payload).forEach(([key, value]) => {
-				document.cookie = `${key}=${value}; path=/`;
-			});
-		},
 		onSuccess: () => {
 			alert('회원가입이 완료되었습니다.');
 			queryClient.invalidateQueries({ queryKey: ['myInfo'] });

--- a/src/service/AuthService.ts
+++ b/src/service/AuthService.ts
@@ -41,7 +41,6 @@ export class AuthService {
 	private mutationOptions = {
 		retry: 3,
 		onSuccess: () => {
-			alert('회원가입이 완료되었습니다.');
 			queryClient.invalidateQueries({ queryKey: ['myInfo'] });
 		},
 		onError: (err: AxiosError | unknown) => {

--- a/src/service/AuthService.ts
+++ b/src/service/AuthService.ts
@@ -1,5 +1,6 @@
 import { FieldValues } from 'react-hook-form';
 import { queryClient } from '../main';
+import { getCookie } from '../util/function/getCookie';
 import axios, { AxiosError } from 'axios';
 import { useMutation, useQuery } from '@tanstack/react-query';
 
@@ -15,7 +16,14 @@ export class AuthService {
 	URL = 'http://localhost:4000';
 
 	private getMyInfo = async (): Promise<IMyInfo> => {
-		return axios.get(`${this.URL}/api/auth/my-info`);
+		const myInfo = {
+			id: getCookie('id') || '',
+			name: getCookie('name') || '',
+			createdAt: getCookie('createdAt') || '',
+			updatedAt: getCookie('updatedAt') || '',
+			profileImage: getCookie('profileImage') || '',
+		};
+		return myInfo;
 	};
 
 	private postSignUp = async (payload: FieldValues) => {

--- a/src/service/AuthService.ts
+++ b/src/service/AuthService.ts
@@ -52,7 +52,7 @@ export class AuthService {
 		});
 	};
 
-	public useSignUpMutation = () => {
+	public usePostSignUpMutation = () => {
 		return useMutation({
 			mutationFn: (payload: FieldValues) => this.postSignUp(payload),
 			...this.mutationOptions,

--- a/src/util/customHook/useCheckAccount.tsx
+++ b/src/util/customHook/useCheckAccount.tsx
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { getCookie } from '../function/getCookie';
+
+const useCheckAccount = () => {
+	const [loginTryCount, setLoginTryCount] = useState(0);
+
+	const navigate = useNavigate();
+
+	const cookieData = {
+		id: getCookie('id'),
+		pw: getCookie('pw'),
+	};
+
+	const handleCheckAccount = (id: string, pw: string) => {
+		if (id !== cookieData.id) {
+			alert('존재하지 않는 아이디입니다.');
+			return;
+		}
+		if (pw !== cookieData.pw) {
+			alert('비밀번호가 일치하지 않습니다.');
+			setLoginTryCount(loginTryCount + 1);
+			return;
+		}
+		navigate('/myinfo');
+	};
+
+	useEffect(() => {
+		if (loginTryCount >= 3) {
+			throw new Error('잘못된 로그인 시도 3회 초과');
+		}
+	}, [loginTryCount]);
+
+	return { handleCheckAccount };
+};
+
+export default useCheckAccount;


### PR DESCRIPTION
- 아이디, 비밀번호 일치 여부 로직을 custom hook으로 분리
- useQuery에서 cookie data 자체를 return하도록 로직 변경
- 쿠키에 데이터 저장하는 로직 자체를 mutationFn에 담음
- mutateAsync 사용하여 가입일 때와 수정일 때 alert 메시지를 다르게 함
- 회원가입 완료 시 login 페이지로 navigate